### PR TITLE
Prepare next version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Deprecated
+- Deprecate `Log4jAdapter` (since Log4J library is deprecated and now classified as highly vulnerable, see
+[CVE-2019-17571](https://nvd.nist.gov/vuln/detail/CVE-2019-17571">)).
+
+## [1.0.0] - 2020-01-06
+### Added
+- Initial release.
+
+[Unreleased]: https://github.com/maximevw/autolog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/maximevw/autolog/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the following Maven dependencies:
 <dependency>
     <groupId>com.github.maximevw</groupId>
     <artifactId>autolog-spring</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 * In a classic Java application, you can use logging methods provided by Autolog without automation by AOP (not
@@ -42,7 +42,7 @@ recommended):
 <dependency>
     <groupId>com.github.maximevw</groupId>
     <artifactId>autolog-core</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -73,10 +73,10 @@ is able to log the information at different places simultaneously. The real logg
 are wrapped in singleton adapters implementing `LoggerInterface`. By default, Autolog provides the following adapters:
 * `JavaLoggerAdapter`: wraps an instance of the classic `java.util.logging.Logger`
 * `Log4j2Adapter`: wraps an instance of `org.apache.logging.log4j.Logger`
-* `Log4jAdapter`: wraps an instance of `org.apache.log4j.Logger`
 * `Slf4jAdapter`: wraps an instance of `org.slf4j.Logger`
 * `SystemOutAdapter`: wraps the standard output (`System.out` and `System.err`)
 * `XSlf4jAdapter`: wraps an instance of `org.slf4j.ext.XLogger`
+* *(Deprecated - don't use anymore)* `Log4jAdapter`: wraps an instance of `org.apache.log4j.Logger`
 
 In Spring Boot applications, the `LoggerManager` can be configured in the application properties (by setting the list
 of `LoggerInterface` implementations to register in the property `autolog.loggers`) thanks to the auto-configuration

--- a/autolog-core/pom.xml
+++ b/autolog-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.maximevw</groupId>
         <artifactId>autolog</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-beta.1</version>
     </parent>
 
     <artifactId>autolog-core</artifactId>

--- a/autolog-core/src/main/java/com/github/maximevw/autolog/core/logger/adapters/Log4jAdapter.java
+++ b/autolog-core/src/main/java/com/github/maximevw/autolog/core/logger/adapters/Log4jAdapter.java
@@ -34,8 +34,12 @@ import java.lang.reflect.Method;
 
 /**
  * This class wraps an instance of {@link Logger} to be used by Autolog.
+ *
+ * @deprecated Use {@link Log4j2Adapter} with Log4J2 instead. Indeed, Log4J is deprecated and now classified as highly
+ * 			   vulnerable (see <a href="https://nvd.nist.gov/vuln/detail/CVE-2019-17571">CVE-2019-17571</a>).
  */
-@API(status = API.Status.STABLE, since = "1.0.0")
+@Deprecated
+@API(status = API.Status.DEPRECATED, since = "1.1.0")
 @Log4j(topic = "Autolog")
 public class Log4jAdapter implements LoggerInterface {
 

--- a/autolog-coverage-reporting/pom.xml
+++ b/autolog-coverage-reporting/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>autolog</artifactId>
         <groupId>com.github.maximevw</groupId>
-        <version>1.0.0</version>
+        <version>1.1.0-beta.1</version>
     </parent>
 
     <artifactId>autolog-coverage-reporting</artifactId>
@@ -33,12 +33,12 @@
         <dependency>
             <groupId>com.github.maximevw</groupId>
             <artifactId>autolog-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-beta.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.maximevw</groupId>
             <artifactId>autolog-spring</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-beta.1</version>
         </dependency>
     </dependencies>
 

--- a/autolog-spring/pom.xml
+++ b/autolog-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.maximevw</groupId>
         <artifactId>autolog</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-beta.1</version>
     </parent>
 
     <artifactId>autolog-spring</artifactId>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.github.maximevw</groupId>
             <artifactId>autolog-core</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-beta.1</version>
         </dependency>
 
         <dependency>

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>
+            <![CDATA[
+            Suppress alerts relative to log4j-1.2.17.jar.
+            The usage of Log4J 1.2 in Autolog is deprecated since version 1.1.0 and the dependency will be removed in a
+            future version.
+            ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/log4j/log4j@.*$</packageUrl>
+        <cpe>cpe:/a:apache:log4j</cpe>
+    </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.maximevw</groupId>
     <artifactId>autolog</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-beta.1</version>
     <packaging>pom</packaging>
 
     <name>Autolog</name>
@@ -71,6 +71,8 @@
 
         <!-- OWASP scan report output directory -->
         <owasp.outputDirectory>${project.build.directory}/owasp</owasp.outputDirectory>
+        <!-- OWASP suppression file -->
+        <owasp.suppressionFile>owasp-suppressions.xml</owasp.suppressionFile>
 
         <!-- Delomboked source code directory -->
         <delombok.outputDirectory>${project.build.directory}/delombok</delombok.outputDirectory>
@@ -80,12 +82,12 @@
 
         <!-- Dependencies and plugins versions management -->
         <apiguardian.version>1.1.0</apiguardian.version>
-        <aspectj.version>1.9.4</aspectj.version>
+        <aspectj.version>1.9.5</aspectj.version>
         <checkstyle.version>8.27</checkstyle.version>
         <commons-lang.version>3.9</commons-lang.version>
         <compile-testing.version>0.18</compile-testing.version>
-        <guava.version>28.1-jre</guava.version>
-        <hamcrest.version>2.1</hamcrest.version>
+        <guava.version>28.2-jre</guava.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jackson-databind.version>2.10.1</jackson-databind.version>
         <jackson-dataformat-xml.version>2.10.1</jackson-dataformat-xml.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
@@ -94,7 +96,7 @@
         <junit-platform.version>1.5.2</junit-platform.version>
         <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
         <log4j.version>1.2.17</log4j.version>
-        <log4j2.version>2.12.1</log4j2.version>
+        <log4j2.version>2.13.0</log4j2.version>
         <lombok.version>1.18.10</lombok.version>
         <lombok-maven-plugin.version>1.18.10.0</lombok-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
@@ -107,9 +109,9 @@
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <mockito.version>3.2.0</mockito.version>
+        <mockito.version>3.2.4</mockito.version>
         <owasp-dependency-check.version>5.2.4</owasp-dependency-check.version>
-        <slf4j.version>1.7.28</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <slf4j-test.version>1.2.0</slf4j-test.version>
         <spring.version>5.2.2.RELEASE</spring.version>
         <spring-boot.version>2.2.2.RELEASE</spring-boot.version>
@@ -613,6 +615,9 @@
                         </executions>
                         <configuration>
                             <outputDirectory>${owasp.outputDirectory}</outputDirectory>
+                            <suppressionFiles>
+                                <suppressionFile>${owasp.suppressionFile}</suppressionFile>
+                            </suppressionFiles>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
- Deprecate Log4jAdapter (since Log4J 1.2 is deprecated and vulnerable)
- Suppress alerts related to Log4J 1.2 in OWASP dependency check
- Update some dependencies
- Add CHANGELOG file